### PR TITLE
Swagger-ui 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Swagger UI (SpringDoc OpenAPI) 추가
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/minicloud/insight/config/SwaggerConfig.java
+++ b/src/main/java/com/minicloud/insight/config/SwaggerConfig.java
@@ -1,0 +1,34 @@
+package com.minicloud.insight.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("MiniCloud Insight - Todo API")
+                        .version("1.0.0")
+                        .description("Todo 관리 및 모니터링 API 문서")
+                        .contact(new Contact()
+                                .name("mgs06380@naver.com")
+                                .email("mgs06380@naver.com")))
+                .servers(List.of(
+                        new Server()
+                                .url("http://localhost:8080")
+                                .description("Local Server"),
+                        new Server()
+                                .url("http://your-aws-ec2-url:8080")
+                                .description("AWS EC2 Server")
+                ));
+    }
+}

--- a/src/main/java/com/minicloud/insight/controller/TodoController.java
+++ b/src/main/java/com/minicloud/insight/controller/TodoController.java
@@ -1,22 +1,24 @@
 package com.minicloud.insight.controller;
 
 import com.minicloud.insight.domain.Todo;
-import com.minicloud.insight.repository.TodoRepository;
 import com.minicloud.insight.service.TodoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.swing.plaf.PanelUI;
 import java.util.List;
 
 @RestController
 @RequestMapping("/api/todos")
 @RequiredArgsConstructor
+@Tag(name = "Todo API", description = "할 일 관리 API")
 public class TodoController {
     private final TodoService todoService;
 
+    @Operation(summary = "전체 Todo 목록 조회")
     @GetMapping // GET 요청 처리
     public ResponseEntity<List<Todo>> getAllTodos(){
         // service에서 모든 할 일 조회
@@ -28,6 +30,7 @@ public class TodoController {
         return ResponseEntity.ok(todos);
     }
 
+    @Operation(summary = "특정 Todo 조회")
     @GetMapping("/{id}")
     public ResponseEntity<Todo> getTodoById(@PathVariable Long id){
         // @PathVariable: URL의 {id} 부분을 파라미터로 받음
@@ -38,6 +41,7 @@ public class TodoController {
         return ResponseEntity.ok(todo);
     }
 
+    @Operation(summary = "새로운 Todo 생성")
     @PostMapping // POST 요청 처리
     public ResponseEntity<Todo> createTodo(@RequestBody Todo todo){
         // @RequestBody: HTTP 요청 Body의 JSON을 Java 객체로 변환
@@ -47,6 +51,7 @@ public class TodoController {
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
+    @Operation(summary = "Todo 수정")
     @PutMapping("/{id}")
     public ResponseEntity<Todo> updateTodo(
             @PathVariable Long id,
@@ -56,18 +61,21 @@ public class TodoController {
         return ResponseEntity.ok(update);
     }
 
+    @Operation(summary = "Todo 삭제")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteTodo(@PathVariable Long id){
         todoService.delete(id);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "완료된 Todo 목록 조회")
     @GetMapping("/completed")
     public ResponseEntity<List<Todo>> getCompletedTodos(){
         List<Todo> completed = todoService.findByCompleted(true);
         return ResponseEntity.ok(completed);
     }
 
+    @Operation(summary = "미완료된 Todo 목록 조회")
     @GetMapping("/active")  // GET 요청, URL: /api/todos/active
     public ResponseEntity<List<Todo>> getActiveTodos() {
         // Service를 통해 미완료 할 일만 조회

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,7 +7,7 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 
-# H2 ?? ???
+# H2 ?? ??
 spring.h2.console.enabled=true
 spring.h2.console.path=/h2-console
 
@@ -19,3 +19,10 @@ spring.jpa.show-sql=true
 # Actuator ??
 management.endpoints.web.exposure.include=*
 management.endpoint.health.show-details=always
+
+# Swagger UI ??
+springdoc.api-docs.path=/api-docs
+springdoc.swagger-ui.path=/swagger-ui.html
+springdoc.swagger-ui.operations-sorter=method
+springdoc.swagger-ui.tags-sorter=alpha
+springdoc.swagger-ui.disable-swagger-default-url=true


### PR DESCRIPTION
📋 Summary
Week 1 Day 4-5: Swagger UI 설정 완료
Todo API 문서 자동화 및 브라우저 기반 테스트 환경 구축

🎯 Changes

### 추가된 파일
* `config/SwaggerConfig.java` - Swagger OpenAPI 설정

### 수정된 파일
* `build.gradle` - SpringDoc OpenAPI 의존성 추가
* `application.properties` - Swagger UI 경로 설정
* `controller/TodoController.java` - Swagger 어노테이션 추가 (@Tag, @Operation)

### Swagger 설정 내용
* **접속 URL**: `http://localhost:8080/swagger-ui.html`
* **API Docs**: `http://localhost:8080/api-docs`
* **제목**: MiniCloud Insight - Todo API
* **버전**: 1.0.0

### API 문서화
| Endpoint | Summary |
|----------|---------|
| GET /api/todos | 전체 Todo 목록 조회 |
| GET /api/todos/{id} | 특정 Todo 조회 |
| POST /api/todos | 새로운 Todo 생성 |
| PUT /api/todos/{id} | Todo 수정 |
| DELETE /api/todos/{id} | Todo 삭제 |
| GET /api/todos/completed | 완료된 Todo 목록 조회 |
| GET /api/todos/active | 미완료된 Todo 목록 조회 |

✅ Testing
* Swagger UI 접속 확인 완료
* 모든 API 엔드포인트 Swagger에서 표시 확인
* "Try it out" 기능으로 CRUD 테스트 완료
* Request/Response 스키마 정상 표시

📸 Screenshot
<!-- Swagger UI 스크린샷을 여기에 추가하면 더 좋아요! -->

🔗 Related Issue
Closes #2