### PR TITLE
Day 5-6: Grafana & Prometheus 연동 및 테스트

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,24 @@ services:
       - '--web.console.templates=/usr/share/prometheus/consoles'
     restart: unless-stopped
 
+  # Grafana
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    networks:
+      - monitoring-network
+    volumes:
+      - grafana-data:/var/lib/grafana
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    restart: unless-stopped
+    depends_on:
+      - prometheus
+
 # 네트워크 설정
 networks:
   monitoring-network:
@@ -44,4 +62,6 @@ networks:
 # 볼륨 설정
 volumes:
   prometheus-data:
+    driver: local
+  grafana-data:
     driver: local

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,18 +1,13 @@
 # Prometheus 글로벌 설정
 global:
-  scrape_interval: 15s      # 15초마다 메트릭 수집
-  evaluation_interval: 15s  # 15초마다 규칙 평가
+  scrape_interval: 15s
+  evaluation_interval: 15s
 
 # Alertmanager 설정 (선택사항)
 alerting:
   alertmanagers:
     - static_configs:
         - targets: []
-
-# 규칙 파일 로드 (선택사항)
-rule_files:
-# - "first_rules.yml"
-# - "second_rules.yml"
 
 # 스크래핑 설정
 scrape_configs:


### PR DESCRIPTION
## 📋 Summary
Week 2 Day 5-6: Grafana 대시보드 구축 완료
Prometheus 데이터를 Grafana로 시각화하여 실시간 모니터링 대시보드 구성

## 🎯 Changes

### 수정된 파일
* `docker-compose.yml` - Grafana 서비스 추가

### Grafana 설정 내용

#### 1. docker-compose.yml Grafana 서비스
- **이미지:** `grafana/grafana:latest`
- **포트:** 3000:3000
- **볼륨:** `grafana-data` (데이터 영속성)
- **환경 변수:**
  - `GF_SECURITY_ADMIN_USER=admin`
  - `GF_SECURITY_ADMIN_PASSWORD=admin`
  - `GF_USERS_ALLOW_SIGN_UP=false`
- **네트워크:** `monitoring-network` (Prometheus와 연결)
- **재시작 정책:** `unless-stopped`
- **의존성:** Prometheus 서비스 후 시작

#### 2. Grafana 대시보드 구성
**대시보드 이름:** MiniCloud Insight - Spring Boot Monitoring

**패널 구성 (5개):**

| 패널 | 쿼리 | 설명 |
|------|------|------|
| CPU 사용률 (%) | `system_cpu_usage * 100` | 시스템 CPU 사용률 실시간 모니터링 |
| JVM Heap 메모리 (MB) | `jvm_memory_used_bytes{area="heap"} / 1024 / 1024` | Heap 메모리 사용량 추적 |
| JVM 전체 메모리 (MB) | `jvm_memory_used_bytes / 1024 / 1024` | 전체 JVM 메모리 사용량 |
| HTTP 요청 수 (req/sec) | `sum(rate(http_server_requests_seconds_count[1m]))` | 초당 HTTP 요청 수 |
| 평균 응답 시간 (초) | `rate(http_server_requests_seconds_sum[1m]) / rate(http_server_requests_seconds_count[1m])` | API 평균 응답 시간 |

#### 3. Prometheus 데이터 소스 연결
- **URL:** `http://prometheus:9090`
- **Access:** Server (default)
- **Scrape Interval:** Prometheus 설정 따름 (5초)

---

## ✅ Testing

### Docker 환경 테스트
```bash
# 전체 스택 실행
docker compose up -d

# 컨테이너 상태 확인
docker compose ps
```

**결과:**
```
NAME            IMAGE                 STATUS
minicloud-app   insight-app          Up
prometheus      prom/prometheus      Up
grafana         grafana/grafana      Up
```

### Grafana 접속 및 설정
**접속:**
- Grafana UI: http://localhost:3000
- 로그인: admin / admin

**데이터 소스 연결:**
```
Connections → Data sources → Add data source
→ Prometheus 선택
→ URL: http://prometheus:9090
→ Save & test
→ ✅ Successfully queried the Prometheus API
```

### 대시보드 생성 및 패널 추가
**생성 과정:**
1. Dashboards → New → New dashboard
2. Add visualization → Prometheus 선택
3. 5개 패널 생성 (CPU, 메모리 2개, HTTP 요청, 응답 시간)
4. 각 패널 쿼리 입력 및 설정
5. 대시보드 저장: "MiniCloud Insight - Spring Boot Monitoring"

### 실시간 모니터링 테스트
**부하 발생:**
- Swagger UI: http://localhost:8080/swagger-ui.html

**API 호출:**
- `GET /api/heavy?n=40` (5회) → CPU 사용률 급증 확인
- `GET /api/memory?sizeMB=100` (2회) → 메모리 사용량 증가 확인
- `GET /api/status` (20회) → HTTP 요청 수 증가 확인
- `GET /api/todos` (30회) → 응답 시간 변화 확인

**Grafana 대시보드 결과:**
- [x] CPU 사용률: 0% → 4.5% 급증 확인 (15:48)
- [x] JVM Heap 메모리: 50MB → 400MB 증가 (15:53)
- [x] JVM 전체 메모리: 100MB → 400MB 증가 (15:53)
- [x] HTTP 요청 수: 0.2 req/s → 0.8 req/s 증가 (15:54)
- [x] 평균 응답 시간: 5ms → 30ms 증가 (15:48)

---

## 📊 대시보드 패널 상세

### 패널 1: CPU 사용률 (%)
**쿼리:**
```
system_cpu_usage * 100
```

**설정:**
- Visualization: Time series
- Unit: Percent (0-100)
- Y축: 자동 조정 (0-5%)
- Legend: `{{instance}}`

**관찰된 변화:**
- 평상시: 0.5% 이하
- `/api/heavy` 호출 시: 4.5%까지 급증

---

### 패널 2: JVM Heap 메모리 (MB)
**쿼리:**
```
jvm_memory_used_bytes{area="heap"} / 1024 / 1024
```

**설정:**
- Visualization: Time series
- Unit: none (MB 표시)
- Legend: `{{id}}`

**관찰된 변화:**
- G1 Eden Space: 50MB → 350MB
- G1 Old Gen: 안정적 유지
- G1 Survivor Space: 소폭 증가

---

### 패널 3: JVM 전체 메모리 (MB)
**쿼리:**
```
jvm_memory_used_bytes / 1024 / 1024
```

**설정:**
- Visualization: Time series
- Unit: none
- Legend: `{{area}} - {{id}}`

**메모리 영역:**
- Heap: 100MB → 400MB
- Non-heap (Metaspace, CodeCache): 안정적

---

### 패널 4: HTTP 요청 수 (req/sec)
**쿼리:**
```
sum(rate(http_server_requests_seconds_count[1m]))
```

**설정:**
- Visualization: Time series
- Unit: requests/sec (reqps)
- Legend: sum(rate(...))

**관찰된 변화:**
- 평상시: 0.2 req/s (Prometheus 스크래핑)
- API 테스트 중: 0.8 req/s까지 증가

---

### 패널 5: 평균 응답 시간 (초)
**쿼리:**
```
rate(http_server_requests_seconds_sum[1m]) / rate(http_server_requests_seconds_count[1m])
```

**설정:**
- Visualization: Time series
- Unit: seconds (s)
- Y축: 0-0.03s

**관찰된 변화:**
- 평상시: 5ms 이하
- `/api/heavy` 호출 시: 25-30ms로 증가

---

## 🎮 실행 방법

### 전체 스택 실행
```bash
# Docker Compose로 실행
docker compose up -d

# 로그 확인
docker compose logs -f grafana

# 중지
docker compose down
```

### 접속 URL
- **Spring Boot Swagger:** http://localhost:8080/swagger-ui.html
- **Spring Boot Metrics:** http://localhost:8080/actuator/prometheus
- **Prometheus UI:** http://localhost:9090
- **Prometheus Targets:** http://localhost:9090/targets
- **Grafana Dashboard:** http://localhost:3000

### Grafana 로그인
- **Username:** `admin`
- **Password:** `admin`
- 첫 로그인 시 비밀번호 변경 또는 Skip 가능

---

## 🎯 완료 조건

### Day 5-6 체크리스트
- [x] Docker Compose에 Grafana 서비스 추가
- [x] Grafana 초기 설정 (admin 계정)
- [x] Prometheus 데이터 소스 연결
- [x] 새 대시보드 생성
- [x] CPU 사용률 그래프 패널
- [x] JVM Heap 메모리 패널
- [x] JVM 전체 메모리 패널
- [x] HTTP 요청 수 패널
- [x] 평균 응답 시간 패널
- [x] 대시보드 저장
- [x] 자동 새로고침 설정 (5초)
- [x] 부하 테스트 후 실시간 그래프 변화 확인
- [x] 모든 메트릭 정상 수집 확인

---

## 📊 모니터링 아키텍처
```
┌──────────────────────────────────────┐
│     Docker Compose Network           │
│                                      │
│  ┌──────────┐   ┌──────────────┐     │
│  │ Spring   │──▶│  Prometheus │     │
│  │ Boot     │   │    :9090     │     │
│  │ :8080    │   └──────┬───────┘     │
│  └──────────┘          │             │
│                         ▼            │
│                 ┌──────────────┐     │
│                 │   Grafana    │     │
│                 │    :3000     │     │
│                 └──────────────┘     │
└──────────────────────────────────────┘

데이터 흐름:
1. Spring Boot → /actuator/prometheus (메트릭 노출)
2. Prometheus → 5초마다 메트릭 수집
3. Grafana → Prometheus 쿼리하여 시각화
4. 사용자 → Grafana 대시보드에서 실시간 모니터링
```

---

## 🎨 Grafana 주요 기능 활용

### 자동 새로고침
- 대시보드 오른쪽 상단 설정
- 5초 간격으로 자동 새로고침
- 실시간 모니터링 가능

### 시간 범위 선택
- Last 5 minutes
- Last 15 minutes
- Last 1 hour
- Custom range

### 패널 인터랙션
- 그래프 확대/축소
- 시간 범위 드래그 선택
- Legend 클릭으로 시리즈 필터링

---

## 📝 Next Steps (Week 3)

### ELK Stack 연동 (예정)
- [ ] Filebeat 설정
- [ ] Elasticsearch 연동
- [ ] Kibana 대시보드 구성
- [ ] 로그 분석 및 검색

### 추가 개선 사항 (선택)
- [ ] Grafana 알림 규칙 설정
- [ ] 추가 대시보드 패널 (GC, Thread Pool 등)
- [ ] Grafana 프로비저닝 설정 (코드로 관리)
- [ ] 대시보드 JSON 내보내기

---

## 🔗 Related Issue
Closes #5 (Week 2 Day 5-6)

## 📸 Screenshots
<!-- Grafana 대시보드, 각 패널, 실시간 변화 스크린샷 추가하면 더 좋아요! -->

---

## 🎓 학습 내용

### Grafana 대시보드 구성
- Prometheus 데이터 소스 연결
- PromQL 쿼리 작성 및 시각화
- 패널 설정 및 커스터마이징
- Time series 그래프 활용

### 실시간 모니터링
- CPU 사용률 추적
- 메모리 사용량 모니터링
- HTTP 요청 추이 분석
- 응답 시간 성능 측정

### Docker Compose 멀티 서비스 관리
- 3개 서비스 통합 관리 (Spring Boot, Prometheus, Grafana)
- 서비스 간 의존성 설정 (depends_on)
- 네트워크를 통한 서비스 디스커버리
- 볼륨을 통한 데이터 영속성