### PR TITLE
ElasticSearch 환경 구축

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - monitoring-network
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+    volumes:
+      - app-logs:/app/logs
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 30s
@@ -54,6 +56,24 @@ services:
     depends_on:
       - prometheus
 
+  # Elasticsearch
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
+    container_name: elasticsearch
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    networks:
+      - monitoring-network
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    restart: unless-stopped
+
 # 네트워크 설정
 networks:
   monitoring-network:
@@ -64,4 +84,8 @@ volumes:
   prometheus-data:
     driver: local
   grafana-data:
+    driver: local
+  app-logs:
+    driver: local
+  elasticsearch-data:
     driver: local


### PR DESCRIPTION
## 📋 Summary
Week 3 Day 1: Elasticsearch 설정 완료
ELK Stack 구축의 첫 단계로 Elasticsearch를 Docker Compose에 추가하고 정상 작동 확인

## 🎯 Changes

### 수정된 파일
* `docker-compose.yml` - Elasticsearch 서비스 추가 및 로그 볼륨 설정

### Elasticsearch 설정 내용

#### 1. Elasticsearch 서비스 추가
- **이미지:** `docker.elastic.co/elasticsearch/elasticsearch:8.11.0`
- **컨테이너명:** `elasticsearch`
- **포트:**
  - `9200:9200` - REST API 포트
  - `9300:9300` - 노드 간 통신 포트
- **네트워크:** `monitoring-network` (기존 서비스와 연결)

#### 2. 환경 변수 설정
```yaml
environment:
  - discovery.type=single-node        # 단일 노드 클러스터
  - ES_JAVA_OPTS=-Xms512m -Xmx512m   # JVM 메모리 512MB
  - xpack.security.enabled=false      # 보안 비활성화 (개발용)
  - xpack.security.enrollment.enabled=false
```

**설명:**
- `discovery.type=single-node`: 프로덕션 모드 경고 제거, 단일 노드 최적화
- `ES_JAVA_OPTS`: 힙 메모리 512MB로 제한 (개발 환경 최적화)
- `xpack.security.enabled=false`: 인증 없이 접근 가능 (로컬 개발용)

#### 3. 볼륨 설정
```yaml
volumes:
  - elasticsearch-data:/usr/share/elasticsearch/data
```
- Elasticsearch 데이터 영속성 보장
- 컨테이너 재시작 시에도 인덱스 데이터 유지

#### 4. app 서비스 로그 볼륨 추가
```yaml
app:
  volumes:
    - app-logs:/app/logs
```
- Spring Boot 로그 파일을 컨테이너 외부 볼륨에 저장
- Filebeat와 로그 파일 공유 준비

---

## ✅ Testing

### Docker 환경 테스트
```bash
# 전체 스택 실행
docker compose up -d

# 컨테이너 상태 확인
docker compose ps
```

**결과:**
```
NAME            IMAGE                       STATUS
minicloud-app   insight-app                Up
prometheus      prom/prometheus            Up
grafana         grafana/grafana            Up
elasticsearch   elasticsearch:8.11.0       Up
```

### Elasticsearch 로그 확인
```bash
docker compose logs elasticsearch
```

**정상 로그:**
- ✅ License [xxx] mode [basic] - valid
- ✅ Node is selected as the current health node
- ✅ 템플릿 및 정책 자동 생성 완료

### REST API 접속 테스트
**접속:**
```
http://localhost:9200
```

**응답:**
```json
{
  "name" : "elasticsearch",
  "cluster_name" : "docker-cluster",
  "cluster_uuid" : "VprpYQwqSvaX6g1roIeBHQ",
  "version" : {
    "number" : "8.11.0",
    "build_flavor" : "default",
    "build_type" : "docker"
  },
  "tagline" : "You Know, for Search"
}
```

### 클러스터 상태 확인
**접속:**
```
http://localhost:9200/_cluster/health?pretty
```

**응답:**
```json
{
  "cluster_name" : "docker-cluster",
  "status" : "green",
  "number_of_nodes" : 1,
  "number_of_data_nodes" : 1,
  "active_shards_percent_as_number" : 100.0
}
```
✅ **Status: GREEN** - 완벽한 상태!

### 인덱스 목록 확인
**접속:**
```
http://localhost:9200/_cat/indices?v
```

**응답:**
```
health status index uuid pri rep docs.count docs.deleted store.size pri.store.size
(비어있음 - 정상: 아직 데이터 없음)
```

---

## 📊 시스템 아키텍처

### 현재 구성 (4개 서비스)
```
┌────────────────────────────────────────┐
│      Docker Compose Network            │
│                                        │
│  ┌──────────┐    ┌──────────────┐      │
│  │ Spring   │───▶│  Prometheus │      │
│  │ Boot     │    │    :9090     │      │
│  │ :8080    │    └──────┬───────┘      │
│  └────┬─────┘           │              │
│       │                 ▼              │
│       │         ┌──────────────┐       │
│       │         │   Grafana    │       │
│       │         │    :3000     │       │
│       │         └──────────────┘       │
│       │                                │
│       │ (로그 볼륨 준비)                │
│       ▼                                │
│  [app-logs]                            │
│                                        │
│  ┌──────────────┐                      │
│  │Elasticsearch │  ← Day 1 추가!       │
│  │    :9200     │                      │
│  └──────────────┘                      │
└────────────────────────────────────────┘
```

### Week 3 완성 예정 아키텍처
```
Spring Boot → 로그 파일 (app-logs 볼륨)
                    ↓
                Filebeat (수집)
                    ↓
              Elasticsearch (저장)
                    ↓
                Kibana (시각화)
```

---

## 🛠 실행 방법

### 전체 스택 실행
```bash
# Docker Compose로 실행
docker compose up -d

# 로그 확인
docker compose logs -f elasticsearch

# 중지
docker compose down
```

### 접속 URL
- **Spring Boot:** http://localhost:8080
- **Prometheus:** http://localhost:9090
- **Grafana:** http://localhost:3000
- **Elasticsearch:** http://localhost:9200 ← 새로 추가!

### Elasticsearch API 테스트
```bash
# 클러스터 정보
curl http://localhost:9200

# 클러스터 상태
curl http://localhost:9200/_cluster/health?pretty

# 인덱스 목록
curl http://localhost:9200/_cat/indices?v

# 노드 정보
curl http://localhost:9200/_cat/nodes?v
```

---

## 🎯 완료 조건

### Day 1 체크리스트
- [x] docker-compose.yml에 Elasticsearch 추가
- [x] 환경 변수 설정 (단일 노드, 메모리, 보안)
- [x] elasticsearch-data 볼륨 추가
- [x] app-logs 볼륨 추가 (Spring Boot)
- [x] docker compose up -d 실행 성공
- [x] Elasticsearch 정상 실행 확인
- [x] http://localhost:9200 접속 성공
- [x] 클러스터 상태 GREEN 확인
- [x] 라이선스 활성화 확인
- [x] 인덱스 API 정상 작동 확인

---

## 📝 기술 상세

### Elasticsearch 버전
- **Version:** 8.11.0
- **Build Type:** Docker
- **License:** Basic (Free)

### 클러스터 설정
- **Cluster Name:** docker-cluster
- **Discovery Type:** single-node
- **Nodes:** 1 (data node)
- **JVM Heap:** 512MB (Xms=Xmx)

### 보안 설정
- **X-Pack Security:** Disabled (개발 환경)
- **TLS/SSL:** Disabled
- **Authentication:** None

---

## 🐛 문제 해결 가이드

### 메모리 부족 시
```yaml
environment:
  - ES_JAVA_OPTS=-Xms256m -Xmx256m  # 512MB → 256MB
```

### 포트 충돌 시
```yaml
ports:
  - "9201:9200"  # 9200 → 9201
```

### vm.max_map_count 에러 (WSL)
```bash
wsl -d docker-desktop
sysctl -w vm.max_map_count=262144
```

## 🔗 Related Issue
Part of #[Issue번호] (Week 3 Day 1)
---