### PR TITLE
Filebeat 환경 구축 및 ES, Kibana 연동

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,22 @@ services:
     depends_on:
       - elasticsearch
 
+  # Filebeat
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:8.11.0
+    container_name: filebeat
+    user: root
+    networks:
+      - monitoring-network
+    volumes:
+      - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - app-logs:/app/logs:ro
+      - filebeat-data:/usr/share/filebeat/data
+    command: filebeat -e -strict.perms=false
+    restart: unless-stopped
+    depends_on:
+      - elasticsearch
+      - app
 # 네트워크 설정
 networks:
   monitoring-network:
@@ -105,4 +121,6 @@ volumes:
   app-logs:
     driver: local
   elasticsearch-data:
+    driver: local
+  filebeat-data:
     driver: local

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -1,0 +1,55 @@
+# Filebeat 설정 파일
+
+# 입력 설정 (어떤 로그 파일을 읽을지)
+filebeat.inputs:
+  # Spring Boot 로그 수집
+  - type: filestream
+    id: spring-logs
+    enabled: true
+    paths:
+      - /app/logs/spring.log
+      - /app/logs/spring-error.log
+
+    # JSON 파싱 설정
+    parsers:
+      - ndjson:
+          keys_under_root: true
+          add_error_key: true
+          overwrite_keys: true
+
+    # 필드 추가
+    fields:
+      log_type: spring-boot
+      application: minicloud-insight
+    fields_under_root: true
+
+# 출력 설정 (어디로 보낼지)
+output.elasticsearch:
+  hosts: ["elasticsearch:9200"]
+
+  # 인덱스 설정
+  indices:
+    - index: "spring-logs-%{+yyyy.MM.dd}"
+      when.or:
+        - contains:
+            log_type: "spring-boot"
+
+  # 인덱스 템플릿 설정
+  setup.template.name: "spring-logs"
+  setup.template.pattern: "spring-logs-*"
+
+# 로깅 설정
+logging.level: info
+logging.to_files: true
+logging.files:
+  path: /var/log/filebeat
+  name: filebeat
+  keepfiles: 7
+  permissions: 0644
+
+# 프로세서 설정 (데이터 가공)
+processors:
+  - add_host_metadata:
+      when.not.contains.tags: forwarded
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~


### PR DESCRIPTION
## 📋 Summary
Week 3 Day 4: Filebeat 설정 완료
Spring Boot 로그 파일을 Filebeat로 수집하여 Elasticsearch로 전송, Kibana에서 실시간 로그 확인 가능

## 🎯 Changes

### 추가된 파일
* `filebeat/filebeat.yml` - Filebeat 설정 파일

### 수정된 파일
* `docker-compose.yml` - Filebeat 서비스 추가

### Filebeat 설정 내용

#### 1. filebeat/filebeat.yml 구성

**입력 설정 (filebeat.inputs):**
```yaml
filebeat.inputs:
  - type: filestream
    id: spring-logs
    enabled: true
    paths:
      - /app/logs/spring.log
      - /app/logs/spring-error.log
```

**JSON 파싱:**
```yaml
parsers:
  - ndjson:
      keys_under_root: true
      add_error_key: true
      overwrite_keys: true
```

**필드 추가:**
```yaml
fields:
  log_type: spring-boot
  application: minicloud-insight
fields_under_root: true
```

**Elasticsearch 출력:**
```yaml
output.elasticsearch:
  hosts: ["elasticsearch:9200"]
  indices:
    - index: "spring-logs-%{+yyyy.MM.dd}"
```

#### 2. docker-compose.yml Filebeat 서비스
```yaml
filebeat:
  image: docker.elastic.co/beats/filebeat:8.11.0
  container_name: filebeat
  user: root
  networks:
    - monitoring-network
  volumes:
    - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
    - app-logs:/app/logs:ro
    - filebeat-data:/usr/share/filebeat/data
  command: filebeat -e -strict.perms=false
  restart: unless-stopped
  depends_on:
    - elasticsearch
    - app
```

**주요 설정:**
- **user: root**: 로그 파일 읽기 권한
- **volumes**: 
  - 설정 파일 마운트 (읽기 전용)
  - app-logs 볼륨 공유 (Spring Boot와 공유)
  - filebeat-data (읽은 위치 추적용)
- **command**: 
  - `-e`: stderr로 로그 출력
  - `-strict.perms=false`: 개발 환경 권한 체크 비활성화
- **depends_on**: Elasticsearch, Spring Boot 먼저 시작

#### 3. 볼륨 추가
```yaml
volumes:
  filebeat-data:
    driver: local
```

---

## ✅ Testing

### Docker 환경 테스트
```bash
# 전체 스택 실행
docker compose down
docker compose up -d

# 컨테이너 상태 확인
docker compose ps
```

**결과:**
```
NAME            IMAGE                 STATUS
minicloud-app   insight-app          Up
prometheus      prom/prometheus      Up
grafana         grafana/grafana      Up
elasticsearch   elasticsearch        Up
kibana          kibana               Up
filebeat        filebeat:8.11.0      Up  ← 새로 추가!
```

### Filebeat 로그 확인
```bash
docker compose logs filebeat
```

**정상 로그:**
```
INFO [publisher_pipeline_output] Connection to elasticsearch established
INFO [input.filestream] Harvester started for file: /app/logs/spring.log
INFO [input.filestream] Harvester started for file: /app/logs/spring-error.log
```

✅ **Harvester started 메시지 확인**

### Elasticsearch 인덱스 확인

**접속:**
```
http://localhost:9200/_cat/indices?v
```

**결과:**
```
health status index                    pri rep docs.count store.size
yellow open   spring-logs-2025.11.03    1   1        128    101.5kb
```

✅ **spring-logs-2025.11.03 인덱스 생성됨**
✅ **128개 로그 수집**

### Elasticsearch 데이터 확인

**접속:**
```
http://localhost:9200/spring-logs-*/_search?pretty&size=5
```

**결과:**
```json
{
  "hits": {
    "total": {
      "value": 128
    },
    "hits": [
      {
        "_index": "spring-logs-2025.11.03",
        "_source": {
          "@timestamp": "2025-11-03T06:14:13.830Z",
          "level": "INFO",
          "message": "INFO 레벨 로그 - 일반 정보 메시지",
          "logger_name": "com.minicloud.insight.controller.MonitoringController",
          "thread_name": "http-nio-8080-exec-4",
          "log_type": "spring-boot",
          "application": "minicloud-insight",
          "agent": {
            "type": "filebeat",
            "version": "8.11.0"
          }
        }
      }
    ]
  }
}
```

✅ **JSON 로그 정상 저장**
✅ **모든 필드 수집 (level, message, logger_name, thread_name, stack_trace)**

---

## 🎨 Kibana 설정 및 테스트

### 1️⃣ Data View 생성

**경로:**
```
Management → Stack Management → Data Views → Create data view
```

**설정:**
```
Name: Spring Logs
Index pattern: spring-logs-*
Timestamp field: @timestamp
```

✅ **Data View 생성 완료**

### 2️⃣ Discover에서 로그 확인

**경로:**
```
Analytics → Discover → Spring Logs 선택
```

**확인 사항:**
- ✅ 128개 로그 표시
- ✅ 시간별 히스토그램 그래프
- ✅ 로그 테이블 (level, message, logger_name 등)

### 3️⃣ 필드 확인

**Selected fields:**
```
✅ @timestamp
✅ level (INFO, WARN, ERROR)
✅ message
✅ logger_name
✅ thread_name
✅ log_type (spring-boot)
✅ application (minicloud-insight)
```

**에러 로그 필드:**
```
✅ stack_trace (Java 전체 스택 트레이스)
```

### 4️⃣ 검색 테스트

**에러 로그만 필터링:**
```
level: "ERROR"
```

**특정 메시지 검색:**
```
message: "RuntimeException"
```

**특정 컨트롤러 검색:**
```
logger_name: "*MonitoringController*"
```

✅ **모든 검색 기능 정상 작동**

---

## 🧪 실시간 로그 테스트

### API 호출

**Swagger에서:**
```
GET /api/log-test (3회)
GET /api/error?type=runtime (2회)
GET /api/status (5회)
```

### Kibana에서 확인

**Discover 화면:**
- 오른쪽 상단 Refresh 클릭
- 새 로그 즉시 표시됨
- 총 로그 수 증가 (128 → 143)

✅ **실시간 로그 수집 확인**

---

## 📊 수집된 로그 통계

### 로그 분포
```
총 로그: 128개
- INFO: ~70개
- WARN: ~15개
- ERROR: ~43개
```

### 파일별 수집
```
/app/logs/spring.log: 85개 (모든 레벨)
/app/logs/spring-error.log: 43개 (ERROR만)
```

### 주요 로거
```
- com.minicloud.insight.MiniCloudInsightApplication
- com.minicloud.insight.controller.MonitoringController
- org.springframework.*
- org.apache.catalina.*
```

---

## 📊 데이터 흐름
```
Spring Boot 애플리케이션
    ↓
Logback (JSON 로그 생성)
    ↓
/app/logs/spring.log
/app/logs/spring-error.log
    ↓
Filebeat (파일 읽기)
    ↓
JSON 파싱 & 필드 추가
    ↓
Elasticsearch (인덱스 저장)
    ↓
Kibana (검색 & 시각화)
```

---

## 🛠 실행 방법

### 전체 스택 실행
```bash
# Docker Compose로 실행
docker compose up -d

# 로그 확인
docker compose logs -f filebeat

# 중지
docker compose down
```

### 접속 URL
- **Spring Boot Swagger:** http://localhost:8080/swagger-ui.html
- **Prometheus:** http://localhost:9090
- **Grafana:** http://localhost:3000
- **Elasticsearch:** http://localhost:9200
- **Elasticsearch Indices:** http://localhost:9200/_cat/indices?v
- **Kibana:** http://localhost:5601
- **Kibana Discover:** http://localhost:5601/app/discover

### Filebeat 상태 확인
```bash
# Filebeat 로그
docker compose logs filebeat

# Filebeat 컨테이너 접속
docker exec -it filebeat bash

# 설정 파일 확인
docker exec -it filebeat cat /usr/share/filebeat/filebeat.yml
```

---

## 🎯 완료 조건

### Day 4 체크리스트
- [x] filebeat 디렉토리 생성
- [x] filebeat.yml 설정 파일 작성
- [x] JSON 파서 설정 (ndjson)
- [x] 필드 추가 설정 (log_type, application)
- [x] Elasticsearch 출력 설정
- [x] 날짜별 인덱스 패턴 설정 (spring-logs-YYYY.MM.DD)
- [x] docker-compose.yml에 Filebeat 서비스 추가
- [x] app-logs 볼륨 공유 (읽기 전용)
- [x] filebeat-data 볼륨 추가
- [x] docker compose up -d 실행
- [x] 6개 컨테이너 모두 Up 확인
- [x] Filebeat 로그 확인 (Harvester started)
- [x] Elasticsearch 인덱스 생성 확인
- [x] 로그 데이터 수집 확인 (128개)
- [x] Kibana Data View 생성
- [x] Kibana Discover에서 로그 확인
- [x] 검색 기능 테스트
- [x] 실시간 로그 수집 확인

---

## 📝 Next Steps (Day 5-6)

### Kibana 대시보드 구축 예정
- [ ] 로그 레벨별 파이 차트
- [ ] 시간별 로그 발생 추이 그래프
- [ ] 에러 로그 Top 10
- [ ] HTTP 요청 로그 분석
- [ ] 로거별 통계
- [ ] 대시보드 저장 및 공유

---

## 🔗 Related Issue
Part of #[Issue번호] (Week 3 Day 4)

## 📸 Screenshots
<!-- Kibana Discover, Elasticsearch 인덱스, 로그 검색 스크린샷 추가 -->

---

## 🎓 학습 내용

### Filebeat 개념
- Lightweight log shipper
- 파일 기반 로그 수집
- Elasticsearch 직접 출력
- JSON 파싱 기능

### Filestream Input
- 최신 파일 입력 방식
- 파일 상태 추적 (어디까지 읽었는지)
- 여러 파일 동시 수집
- 파일 로테이션 대응

### NDJSON 파싱
- Newline Delimited JSON
- 각 줄이 독립적인 JSON 객체
- keys_under_root로 필드 병합
- Elasticsearch 최적화

### Docker 볼륨 공유
- app-logs 볼륨을 Spring Boot와 Filebeat가 공유
- 읽기 전용(ro) 마운트로 안전성 확보
- filebeat-data로 상태 영속성 보장

### ELK Stack 통합
- Elasticsearch: 로그 저장 및 검색
- Logstash 대신 Filebeat 사용 (경량화)
- Kibana: 로그 시각화 및 분석