### PR TITLE
Week 3: Complete ELK Stack Setup for Log Monitoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 
 	// Prometheus (Micrometer) ← 이 줄 추가!
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// Logstash Logback Encoder (JSON 로그)
+	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       - monitoring-network
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+    volumes:
+      - app-logs:/app/logs
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/actuator/health"]
       interval: 30s
@@ -54,6 +56,24 @@ services:
     depends_on:
       - prometheus
 
+  # Elasticsearch
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
+    container_name: elasticsearch
+    ports:
+      - "9200:9200"
+      - "9300:9300"
+    networks:
+      - monitoring-network
+    environment:
+      - discovery.type=single-node
+      - ES_JAVA_OPTS=-Xms512m -Xmx512m
+      - xpack.security.enabled=false
+      - xpack.security.enrollment.enabled=false
+    volumes:
+      - elasticsearch-data:/usr/share/elasticsearch/data
+    restart: unless-stopped
+
 # 네트워크 설정
 networks:
   monitoring-network:
@@ -64,4 +84,8 @@ volumes:
   prometheus-data:
     driver: local
   grafana-data:
+    driver: local
+  app-logs:
+    driver: local
+  elasticsearch-data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,22 @@ services:
     depends_on:
       - elasticsearch
 
+  # Filebeat
+  filebeat:
+    image: docker.elastic.co/beats/filebeat:8.11.0
+    container_name: filebeat
+    user: root
+    networks:
+      - monitoring-network
+    volumes:
+      - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+      - app-logs:/app/logs:ro
+      - filebeat-data:/usr/share/filebeat/data
+    command: filebeat -e -strict.perms=false
+    restart: unless-stopped
+    depends_on:
+      - elasticsearch
+      - app
 # 네트워크 설정
 networks:
   monitoring-network:
@@ -105,4 +121,6 @@ volumes:
   app-logs:
     driver: local
   elasticsearch-data:
+    driver: local
+  filebeat-data:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,23 @@ services:
       - elasticsearch-data:/usr/share/elasticsearch/data
     restart: unless-stopped
 
+  # Kibana
+  kibana:
+    image: docker.elastic.co/kibana/kibana:8.11.0
+    container_name: kibana
+    ports:
+      - "5601:5601"
+    networks:
+      - monitoring-network
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+      - ELASTICSEARCH_USERNAME=kibana_system
+      - ELASTICSEARCH_PASSWORD=
+      - XPACK_SECURITY_ENABLED=false
+    restart: unless-stopped
+    depends_on:
+      - elasticsearch
+
 # 네트워크 설정
 networks:
   monitoring-network:

--- a/filebeat/filebeat.yml
+++ b/filebeat/filebeat.yml
@@ -1,0 +1,55 @@
+# Filebeat 설정 파일
+
+# 입력 설정 (어떤 로그 파일을 읽을지)
+filebeat.inputs:
+  # Spring Boot 로그 수집
+  - type: filestream
+    id: spring-logs
+    enabled: true
+    paths:
+      - /app/logs/spring.log
+      - /app/logs/spring-error.log
+
+    # JSON 파싱 설정
+    parsers:
+      - ndjson:
+          keys_under_root: true
+          add_error_key: true
+          overwrite_keys: true
+
+    # 필드 추가
+    fields:
+      log_type: spring-boot
+      application: minicloud-insight
+    fields_under_root: true
+
+# 출력 설정 (어디로 보낼지)
+output.elasticsearch:
+  hosts: ["elasticsearch:9200"]
+
+  # 인덱스 설정
+  indices:
+    - index: "spring-logs-%{+yyyy.MM.dd}"
+      when.or:
+        - contains:
+            log_type: "spring-boot"
+
+  # 인덱스 템플릿 설정
+  setup.template.name: "spring-logs"
+  setup.template.pattern: "spring-logs-*"
+
+# 로깅 설정
+logging.level: info
+logging.to_files: true
+logging.files:
+  path: /var/log/filebeat
+  name: filebeat
+  keepfiles: 7
+  permissions: 0644
+
+# 프로세서 설정 (데이터 가공)
+processors:
+  - add_host_metadata:
+      when.not.contains.tags: forwarded
+  - add_cloud_metadata: ~
+  - add_docker_metadata: ~

--- a/src/main/java/com/minicloud/insight/controller/MonitoringController.java
+++ b/src/main/java/com/minicloud/insight/controller/MonitoringController.java
@@ -197,4 +197,25 @@ public class MonitoringController {
         return ResponseEntity.ok(response);
     }
 
+    /**
+     로그 레벨 테스트
+     */
+    @Operation(
+            summary = "로그 레벨 테스트",
+            description = "모든 로그 레벨(INFO, WARN, ERROR)을 테스트합니다."
+    )
+    @GetMapping("/log-test")
+    public ResponseEntity<Map<String, Object>> logTest() {
+        log.info("INFO 레벨 로그 - 일반 정보 메시지");
+        log.warn("WARN 레벨 로그 - 경고 메시지");
+        log.error("ERROR 레벨 로그 - 에러 메시지 (테스트)");
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", "로그 레벨 테스트 완료");
+        response.put("log_levels", List.of("INFO", "WARN", "ERROR"));
+        response.put("log_file", "/app/logs/spring.log");
+
+        return ResponseEntity.ok(response);
+    }
+
 }

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 변수 정의 -->
+    <property name="LOG_PATH" value="/app/logs"/>
+    <property name="LOG_FILE_NAME" value="spring"/>
+
+    <!-- 콘솔 출력 -->
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <charset>UTF-8</charset>
+        </encoder>
+    </appender>
+
+    <!-- 파일 출력 - 전체 로그 -->
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${LOG_FILE_NAME}.log</file>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <includeMdcKeyName>traceId</includeMdcKeyName>
+            <includeMdcKeyName>spanId</includeMdcKeyName>
+        </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <!-- 에러 로그 별도 파일 -->
+    <appender name="ERROR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_PATH}/${LOG_FILE_NAME}-error.log</file>
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>ERROR</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"/>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_PATH}/${LOG_FILE_NAME}-error-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>100MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+            <maxHistory>30</maxHistory>
+        </rollingPolicy>
+    </appender>
+
+    <!-- 애플리케이션 로거 -->
+    <logger name="com.example.insight" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="ERROR_FILE"/>
+    </logger>
+
+    <!-- Spring Framework 로거 -->
+    <logger name="org.springframework" level="INFO" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </logger>
+
+    <!-- Hibernate 로거 -->
+    <logger name="org.hibernate" level="WARN" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+    </logger>
+
+    <!-- Root 로거 -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="ERROR_FILE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
# Week 3: ELK Stack 로그 모니터링 시스템 구축 완료

## 📋 Summary
Week 3 전체 완료: Elasticsearch, Kibana, Filebeat를 활용한 통합 로그 모니터링 시스템 구축

## 🎯 구현 내용

### 시스템 아키텍처
```
Spring Boot Application
    ↓ (Logback)
JSON 로그 파일 (/app/logs/)
    ↓ (Filebeat)
Elasticsearch (저장 & 검색)
    ↓
Kibana (시각화 & 분석)
```

---

## 📅 Week 3 세부 진행 사항

### ✅ Day 1: Elasticsearch 설치 및 설정
**구현:**
- Elasticsearch 8.11.0 Docker 컨테이너 설정
- Single-node 클러스터 구성
- Security 비활성화 (개발 환경)
- Health check API 확인

**docker-compose.yml:**
```yaml
elasticsearch:
  image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
  ports: ["9200:9200", "9300:9300"]
  environment:
    - discovery.type=single-node
    - ES_JAVA_OPTS=-Xms512m -Xmx512m
    - xpack.security.enabled=false
```

**확인:**
- ✅ Elasticsearch API: http://localhost:9200
- ✅ Cluster health: GREEN/YELLOW
- ✅ elasticsearch-data 볼륨 생성

---

### ✅ Day 2: Kibana 설치 및 설정
**구현:**
- Kibana 8.11.0 Docker 컨테이너 설정
- Elasticsearch 연동
- UI 접근 확인

**docker-compose.yml:**
```yaml
kibana:
  image: docker.elastic.co/kibana/kibana:8.11.0
  ports: ["5601:5601"]
  environment:
    - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
```

**확인:**
- ✅ Kibana UI: http://localhost:5601
- ✅ Elasticsearch 연결 확인
- ✅ Management 메뉴 접근

---

### ✅ Day 3: Logback JSON 로그 설정
**구현:**
- `logback-spring.xml` 설정 파일 작성
- JSON 형식 로그 출력 (Logstash Encoder)
- 로그 파일 분리 (전체/에러)
- Rolling Policy 설정

**파일 구조:**
```
/app/logs/
├── spring.log        # 전체 로그 (INFO, WARN, ERROR)
└── spring-error.log  # 에러만 (ERROR)
```

**logback-spring.xml 주요 설정:**
```xml
<!-- JSON 인코더 -->
<encoder class="net.logstash.logback.encoder.LogstashEncoder">
  <includeMdcKeyName>traceId</includeMdcKeyName>
  <includeMdcKeyName>spanId</includeMdcKeyName>
</encoder>

<!-- Rolling Policy -->
<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
  <fileNamePattern>spring-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
  <maxFileSize>100MB</maxFileSize>
  <maxHistory>30</maxHistory>
</rollingPolicy>
```

**의존성 추가:**
```gradle
implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
```

**로그 포맷:**
```json
{
  "@timestamp": "2025-11-03T06:14:13.830Z",
  "@version": "1",
  "level": "INFO",
  "level_value": 20000,
  "message": "로그 메시지",
  "logger_name": "com.minicloud.insight.controller.MonitoringController",
  "thread_name": "http-nio-8080-exec-4"
}
```

**테스트 엔드포인트 추가:**
```java
@GetMapping("/api/log-test")
public ResponseEntity<Map<String, Object>> logTest() {
    log.info("INFO 레벨 로그 - 일반 정보 메시지");
    log.warn("WARN 레벨 로그 - 경고 메시지");
    log.error("ERROR 레벨 로그 - 에러 메시지 (테스트)");
    return ResponseEntity.ok(response);
}
```

**확인:**
- ✅ JSON 형식 로그 생성
- ✅ 로그 파일 분리 (spring.log, spring-error.log)
- ✅ Stack Trace 포함 (에러 시)
- ✅ Rolling Policy 동작

---

### ✅ Day 4: Filebeat 로그 수집 설정
**구현:**
- `filebeat/filebeat.yml` 설정 파일 작성
- Filestream input으로 로그 파일 읽기
- NDJSON 파서 설정
- Elasticsearch 직접 출력
- 날짜별 인덱스 패턴

**filebeat.yml:**
```yaml
filebeat.inputs:
  - type: filestream
    id: spring-logs
    enabled: true
    paths:
      - /app/logs/spring.log
      - /app/logs/spring-error.log
    parsers:
      - ndjson:
          keys_under_root: true
          add_error_key: true
          overwrite_keys: true
    fields:
      log_type: spring-boot
      application: minicloud-insight
    fields_under_root: true

output.elasticsearch:
  hosts: ["elasticsearch:9200"]
  indices:
    - index: "spring-logs-%{+yyyy.MM.dd}"
```

**docker-compose.yml:**
```yaml
filebeat:
  image: docker.elastic.co/beats/filebeat:8.11.0
  user: root
  volumes:
    - ./filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
    - app-logs:/app/logs:ro
    - filebeat-data:/usr/share/filebeat/data
  command: filebeat -e -strict.perms=false
  depends_on:
    - elasticsearch
    - app
```

**확인:**
- ✅ Filebeat 컨테이너 실행
- ✅ Harvester started 로그
- ✅ Elasticsearch 인덱스 생성 (spring-logs-YYYY.MM.DD)
- ✅ 128개 로그 수집 확인
- ✅ 실시간 로그 수집 (< 30초)

---

### ✅ Day 5-6: Kibana 대시보드 구축
**구현:**
- Data View 생성 (spring-logs-*)
- Discover에서 로그 탐색
- 5개 시각화 패널 생성
- 대시보드 통합 및 레이아웃 조정

#### 1️⃣ Data View 생성
```
Name: Spring Logs
Index pattern: spring-logs-*
Timestamp field: @timestamp
```

#### 2️⃣ 시각화 패널

**A. 로그 레벨 분포 (Pie Chart)**
```
Visualization: Pie
Slice by: level.keyword
Metrics: Count
Result: INFO, WARN, ERROR 비율 표시
```

**B. 시간별 로그 발생 추이 (Line/Area Chart)**
```
Visualization: Line/Area
Horizontal axis: @timestamp
Vertical axis: Count
Break down by: level.keyword
Result: 시간에 따른 로그 레벨별 추이
```

**C. Top 에러 메시지 (Table)**
```
Visualization: Table
Rows: message.keyword (Top 10)
Metrics: Count
Filters: level.keyword is ERROR
Result: 가장 많이 발생한 에러 Top 10
```

**D. Logger별 로그 통계 (Bar Chart)**
```
Visualization: Bar horizontal
Vertical axis: logger_name.keyword (Top 10)
Horizontal axis: Count
Result: 어떤 클래스에서 로그가 많이 발생하는지
```

**E. 최근 에러 로그 (Table)**
```
Visualization: Table
Rows: message.keyword, logger_name.keyword
Metrics: Count
Filters: level.keyword is ERROR
Result: 에러 메시지와 발생 횟수
```

#### 3️⃣ 대시보드 설정
```
Title: Spring Boot Logs Dashboard
Description: MiniCloud Insight 로그 모니터링 대시보드
Tags: spring-boot, logs, monitoring
Time range: Last 24 hours
Auto-refresh: 30 seconds
```

**레이아웃:**
```
┌─────────────────┬─────────────────┐
│  로그 레벨 분포  │  시간별 추이    │
│  (Pie)          │  (Line)         │
├─────────────────┴─────────────────┤
│  Top 에러 메시지                  │
│  (Table)                          │
├─────────────────┬─────────────────┤
│ Logger별 통계   │  최근 에러 로그 │
│ (Bar)           │  (Table)        │
└─────────────────┴─────────────────┘
```

**확인:**
- ✅ 5개 시각화 패널 생성
- ✅ 대시보드 통합
- ✅ 실시간 업데이트 (Auto-refresh)
- ✅ 필터링 기능
- ✅ 시간 범위 조정

---

### ✅ Day 7: 통합 테스트
**테스트 시나리오:**

#### 1️⃣ 에러 발생 → Kibana 확인
```
Swagger → /api/error?type=runtime 호출
→ Kibana Dashboard 확인
→ 에러 카운트 증가 ✅
→ Stack Trace 확인 ✅
```

#### 2️⃣ 로그 검색 쿼리
```
level: "ERROR"                          ✅
message: "RuntimeException"              ✅
logger_name: "*MonitoringController*"   ✅
level: "ERROR" AND message: "Runtime"   ✅
```

#### 3️⃣ Grafana + Kibana 통합
```
Grafana: 메트릭으로 이상 징후 발견
   ↓
Kibana: 로그에서 원인 분석
   ↓
문제 해결!
```

---

## 📊 기술 스택

### ELK Stack
```
- Elasticsearch 8.11.0: 로그 저장 및 검색 엔진
- Logstash → Filebeat: 경량 로그 수집기
- Kibana 8.11.0: 데이터 시각화 및 분석
```

### Spring Boot
```
- Logback: 로그 프레임워크
- Logstash Logback Encoder: JSON 로그 생성
- Spring Boot Actuator: 메트릭 수집
```

### Infrastructure
```
- Docker Compose: 컨테이너 오케스트레이션
- Docker Volumes: 데이터 영속성
```

---

## 🗂️ 파일 구조
```
insight/
├── filebeat/
│   └── filebeat.yml                    # Filebeat 설정
├── src/
│   └── main/
│       ├── java/
│       │   └── com/minicloud/insight/
│       │       └── controller/
│       │           └── MonitoringController.java
│       └── resources/
│           └── logback-spring.xml      # Logback 설정
├── docker-compose.yml                  # 전체 스택 설정
└── build.gradle                        # 의존성
```

---

## 🚀 실행 방법

### 1️⃣ 전체 스택 실행
```bash
docker compose up -d
```

### 2️⃣ 접속 URL
```
Spring Boot:     http://localhost:8080
Swagger:         http://localhost:8080/swagger-ui.html
Prometheus:      http://localhost:9090
Grafana:         http://localhost:3000
Elasticsearch:   http://localhost:9200
Kibana:          http://localhost:5601
```

### 3️⃣ Kibana Dashboard
```
http://localhost:5601
→ Analytics → Dashboard
→ "Spring Boot Logs Dashboard" 선택
```

---

## ✅ 테스트 결과

### 로그 수집
```
✅ 실시간 수집 (30초 이내)
✅ JSON 형식 파싱
✅ 모든 로그 레벨 (INFO, WARN, ERROR)
✅ Stack Trace 포함
✅ 메타데이터 추가 (log_type, application)
```

### Elasticsearch
```
✅ 날짜별 인덱스 생성 (spring-logs-YYYY.MM.DD)
✅ 128+ 로그 저장
✅ 검색 쿼리 정상 작동
✅ 필드 매핑 자동 생성
```

### Kibana
```
✅ Data View 생성
✅ Discover 검색 기능
✅ 5개 시각화 패널
✅ Dashboard 통합
✅ 실시간 Auto-refresh
✅ 필터링 및 시간 범위 조정
```

---

## 📊 모니터링 시스템 완성
```
메트릭 모니터링 (Week 1-2)
├─ Prometheus: 메트릭 수집
├─ Grafana: 시각화
└─ Actuator: 메트릭 노출

로그 모니터링 (Week 3)
├─ Logback: JSON 로그 생성
├─ Filebeat: 로그 수집
├─ Elasticsearch: 저장 & 검색
└─ Kibana: 시각화 & 분석

통합 모니터링
├─ Prometheus + Grafana: "뭔가 이상해!" (숫자)
└─ ELK Stack: "왜 이상한지 보자!" (로그)
```

---

## 🎓 학습 내용

### Elasticsearch
- 분산 검색 및 분석 엔진
- RESTful API
- 인덱스/문서 구조
- 날짜 기반 인덱스 패턴

### Filebeat
- 경량 로그 수집기
- Filestream input
- NDJSON 파싱
- Elasticsearch 직접 출력
- 상태 관리 (registry)

### Kibana
- Data View (Index Pattern)
- Discover (로그 탐색)
- Lens (시각화 도구)
- Dashboard (통합 대시보드)
- KQL (Kibana Query Language)

### Logback
- Appender (출력 대상)
- Encoder (출력 형식)
- Rolling Policy (파일 관리)
- Logger 계층 구조
- JSON 형식 로그

---

## 🔄 데이터 흐름
```
1. 애플리케이션에서 로그 발생
   log.info(), log.error() 호출

2. Logback이 JSON 변환
   {"@timestamp":"...","level":"INFO",...}

3. 파일에 기록
   /app/logs/spring.log

4. Filebeat가 실시간 감시
   새 로그 발견 → 읽기

5. Elasticsearch로 전송
   POST /spring-logs-2025.11.03/_doc

6. Kibana에서 시각화
   Dashboard로 실시간 모니터링
```

---

## 🎯 달성 목표
```
✅ 로그 통합 수집 시스템 구축
✅ 실시간 로그 모니터링
✅ 로그 검색 및 분석
✅ 시각화 대시보드
✅ 에러 추적 기능
✅ Grafana 메트릭과 연계
✅ Docker 기반 운영
```

---

## 📝 향후 개선 사항 (Optional)
```
□ Elasticsearch ILM (Index Lifecycle Management)
□ Kibana 알림 설정
□ 더 많은 대시보드 패널
□ APM (Application Performance Monitoring)
□ 로그 기반 메트릭
□ 사용자 행동 분석
```

---

## 🔗 Related PRs
- Week 1-2: #[PR번호] Prometheus + Grafana 메트릭 모니터링

## 📸 Screenshots
<!-- Kibana Dashboard, Discover, 시각화 패널 스크린샷 -->

---

## ✅ Checklist

- [x] Elasticsearch 설치 및 설정
- [x] Kibana 설치 및 설정
- [x] Logback JSON 로그 설정
- [x] Filebeat 로그 수집 설정
- [x] Data View 생성
- [x] Kibana Dashboard 구축
- [x] 통합 테스트 완료
- [x] 문서화 (README)
- [x] 실행 가능 확인

---

## 🎉 결과

**운영 수준의 통합 모니터링 시스템 완성!**

- 📊 메트릭: Prometheus + Grafana
- 📝 로그: ELK Stack
- 🔄 실시간 수집 및 시각화
- 🔍 강력한 검색 및 분석 기능
```